### PR TITLE
Corrected docs for type of Revision.bytes and Page.namespace

### DIFF
--- a/mwtypes/page.py
+++ b/mwtypes/page.py
@@ -20,7 +20,7 @@ class Page(jsonable.Type):
             :annotation: = Page title: str
 
         .. autoattribute:: mwtypes.Page.namespace
-            :annotation: = Namespace ID: str
+            :annotation: = Namespace ID: int
 
         .. autoattribute:: mwtypes.Page.redirect
             :annotation: = Page name that this page redirects to : str | None

--- a/mwtypes/revision.py
+++ b/mwtypes/revision.py
@@ -108,7 +108,7 @@ class Revision(jsonable.Type):
             :annotation: = Content of text : str | None
 
         .. autoattribute:: mwtypes.Revision.bytes
-            :annotation: = Number of bytes of content : str | None
+            :annotation: = Number of bytes of content : int | None
 
         .. autoattribute:: mwtypes.Revision.sha1
             :annotation: = sha1 hash of the content : str | None
@@ -174,7 +174,7 @@ class Revision(jsonable.Type):
 
         self.bytes = none_or(bytes, int)
         """
-        Number of bytes of content : `str`
+        Number of bytes of content : `int`
         """
 
         self.sha1 = none_or(sha1, str)


### PR DESCRIPTION
I've found out that the documentation says that Revision.bytes and Page.namespace are strings but they are actually integers.