### PR TITLE
Standalone version of 7z

### DIFF
--- a/mwtypes/files/p7z.py
+++ b/mwtypes/files/p7z.py
@@ -15,7 +15,7 @@ def reader(path):
             the path to the dump file to read
     """
     p = subprocess.Popen(
-        ['7z', 'e', '-so', path],
+        ['7za', 'e', '-so', path],
         stdout=subprocess.PIPE,
         stderr=file_open(os.devnull, "w")
     )


### PR DESCRIPTION
7za is more widely handled than 7z, this seems quite important when acess to package install is not available (eg. distant server)