### PR TITLE
migrate from nose to pytest

### DIFF
--- a/mwtypes/files/tests/test_functions.py
+++ b/mwtypes/files/tests/test_functions.py
@@ -1,7 +1,7 @@
 import io
 import os
 
-from nose.tools import eq_, raises
+from pytest import raises
 
 from ..functions import concat, extract_extension, normalize_path, reader
 
@@ -11,27 +11,27 @@ def test_concat():
     f = io.StringIO("Foobar2")
     end = "Foobar3"
 
-    eq_(concat(start, f, end).read(), "Foobar1Foobar2Foobar3")
+    assert concat(start, f, end).read() == "Foobar1Foobar2Foobar3"
 
 
 def test_extract_extension():
-    eq_(extract_extension("foo")[1], None)
-    eq_(extract_extension("foo.xml")[1], "xml")
-    eq_(extract_extension("foo.xml.gz")[1], "gz")
-    eq_(extract_extension("foo.xml.bz2")[1], "bz2")
-    eq_(extract_extension("foo.xml-p10001p10200.7z")[1], "7z")
+    assert extract_extension("foo")[1] == None
+    assert extract_extension("foo.xml")[1] == "xml"
+    assert extract_extension("foo.xml.gz")[1] == "gz"
+    assert extract_extension("foo.xml.bz2")[1] == "bz2"
+    assert extract_extension("foo.xml-p10001p10200.7z")[1] == "7z"
 
 
-@raises(FileNotFoundError)
 def test_normalize_path_noexist():
-    normalize_path("IDONTEXIST!!!")
+    with raises(FileNotFoundError):
+        normalize_path("IDONTEXIST!!!")
 
 
-@raises(IsADirectoryError)
 def test_normalize_path_directory():
-    normalize_path(os.path.dirname(__file__))
+    with raises(IsADirectoryError):
+        normalize_path(os.path.dirname(__file__))
 
 
 def test_open():
     f = io.StringIO()
-    eq_(f, reader(f))
+    assert f == reader(f)

--- a/mwtypes/files/tests/test_p7z.py
+++ b/mwtypes/files/tests/test_p7z.py
@@ -1,10 +1,8 @@
 import os.path
 
-from nose.tools import eq_
-
 from ..p7z import reader
 
 
 def test_open_file():
     f = reader(os.path.join(os.path.dirname(__file__), "foo.7z"))
-    eq_(f.read(), "foo\n")
+    assert f.read() == "foo\n"

--- a/mwtypes/tests/test_log_item.py
+++ b/mwtypes/tests/test_log_item.py
@@ -1,7 +1,5 @@
 import pickle
 
-from nose.tools import eq_
-
 from ..log_item import Deleted, LogItem, Page
 from ..timestamp import Timestamp
 from ..user import User
@@ -10,16 +8,16 @@ from ..user import User
 def test_log_item():
     # No info
     l = LogItem(10, Timestamp("20150101000000"))
-    eq_(l.id, 10)
-    eq_(l.timestamp, Timestamp("20150101000000"))
-    eq_(l.comment, None)
-    eq_(l.user, None)
-    eq_(l.page, None)
-    eq_(l.type, None)
-    eq_(l.action, None)
-    eq_(l.text, None)
-    eq_(l.params, None)
-    eq_(l.deleted, None)
+    assert l.id == 10
+    assert l.timestamp == Timestamp("20150101000000")
+    assert l.comment == None
+    assert l.user == None
+    assert l.page == None
+    assert l.type == None
+    assert l.action == None
+    assert l.text == None
+    assert l.params == None
+    assert l.deleted == None
 
     # All info
     l = LogItem(10, Timestamp("20150101000000"),
@@ -32,73 +30,73 @@ def test_log_item():
                 params="I am the params",
                 deleted=Deleted(action=True, comment=False, user=False,
                                 restricted=False))
-    eq_(l.id, 10)
-    eq_(l.timestamp, Timestamp("20150101000000"))
-    eq_(l.comment, "I have a lovely bunch of ...")
-    eq_(l.user.id, 10)
-    eq_(l.user.text, "Foobar")
-    eq_(l.page.namespace, 0)
-    eq_(l.page.title, "Anarchism")
-    eq_(l.type, "foo")
-    eq_(l.action, "bar")
-    eq_(l.text, "I am the text")
-    eq_(l.params, "I am the params")
-    eq_(l.deleted.action, True)
-    eq_(l.deleted.comment, False)
-    eq_(l.deleted.user, False)
-    eq_(l.deleted.restricted, False)
+    assert l.id == 10
+    assert l.timestamp == Timestamp("20150101000000")
+    assert l.comment == "I have a lovely bunch of ..."
+    assert l.user.id == 10
+    assert l.user.text == "Foobar"
+    assert l.page.namespace == 0
+    assert l.page.title == "Anarchism"
+    assert l.type == "foo"
+    assert l.action == "bar"
+    assert l.text == "I am the text"
+    assert l.params == "I am the params"
+    assert l.deleted.action == True
+    assert l.deleted.comment == False
+    assert l.deleted.user == False
+    assert l.deleted.restricted == False
 
     # JSON and Pickle
-    eq_(l, LogItem(l.to_json()))
-    eq_(l, pickle.loads(pickle.dumps(l)))
+    assert l == LogItem(l.to_json())
+    assert l == pickle.loads(pickle.dumps(l))
 
 
 def test_deleted():
     # No info
     d = Deleted()
-    eq_(d.action, None)
-    eq_(d.comment, None)
-    eq_(d.user, None)
-    eq_(d.restricted, None)
+    assert d.action == None
+    assert d.comment == None
+    assert d.user == None
+    assert d.restricted == None
 
     # Just one
     d = Deleted(action=True)
-    eq_(d.action, True)
-    eq_(d.comment, None)
-    eq_(d.user, None)
-    eq_(d.restricted, None)
+    assert d.action == True
+    assert d.comment == None
+    assert d.user == None
+    assert d.restricted == None
 
     # All
     d = Deleted(action=True, comment=False, user=True, restricted=False)
-    eq_(d.action, True)
-    eq_(d.comment, False)
-    eq_(d.user, True)
-    eq_(d.restricted, False)
+    assert d.action == True
+    assert d.comment == False
+    assert d.user == True
+    assert d.restricted == False
 
     d = Deleted.from_int(0)
-    eq_(d.action, False)
-    eq_(d.comment, False)
-    eq_(d.user, False)
-    eq_(d.restricted, False)
+    assert d.action == False
+    assert d.comment == False
+    assert d.user == False
+    assert d.restricted == False
 
     d = Deleted.from_int(3)
-    eq_(d.action, True)
-    eq_(d.comment, True)
-    eq_(d.user, False)
-    eq_(d.restricted, False)
+    assert d.action == True
+    assert d.comment == True
+    assert d.user == False
+    assert d.restricted == False
 
     d = Deleted.from_int(9)
-    eq_(d.action, True)
-    eq_(d.comment, False)
-    eq_(d.user, False)
-    eq_(d.restricted, True)
+    assert d.action == True
+    assert d.comment == False
+    assert d.user == False
+    assert d.restricted == True
 
     d = Deleted.from_int(15)
-    eq_(d.action, True)
-    eq_(d.comment, True)
-    eq_(d.user, True)
-    eq_(d.restricted, True)
+    assert d.action == True
+    assert d.comment == True
+    assert d.user == True
+    assert d.restricted == True
 
     # JSON and Pickle
-    eq_(d, Deleted(d.to_json()))
-    eq_(d, pickle.loads(pickle.dumps(d)))
+    assert d == Deleted(d.to_json())
+    assert d == pickle.loads(pickle.dumps(d))

--- a/mwtypes/tests/test_namespace.py
+++ b/mwtypes/tests/test_namespace.py
@@ -1,30 +1,28 @@
 import pickle
 
-from nose.tools import eq_
-
 from ..namespace import Namespace
 
 
 def test_namespace():
     # Minimal arguments
     n = Namespace(10, 'Foobar')
-    eq_(n.id, 10)
-    eq_(n.name, 'Foobar')
-    eq_(n.aliases, None)
-    eq_(n.case, None)
-    eq_(n.canonical, None)
-    eq_(n.content, None)
+    assert n.id == 10
+    assert n.name == 'Foobar'
+    assert n.aliases == None
+    assert n.case == None
+    assert n.canonical == None
+    assert n.content == None
 
     # All the arguments
     n = Namespace(10, 'Foobar', aliases={'Foob', 'Bar'}, case='first-upper',
                   canonical='Ferpbar', content=False)
-    eq_(n.id, 10)
-    eq_(n.name, 'Foobar')
-    eq_(n.aliases, {'Foob', 'Bar'})
-    eq_(n.case, "first-upper")
-    eq_(n.canonical, "Ferpbar")
-    eq_(n.content, False)
+    assert n.id == 10
+    assert n.name == 'Foobar'
+    assert n.aliases == {'Foob', 'Bar'}
+    assert n.case == "first-upper"
+    assert n.canonical == "Ferpbar"
+    assert n.content == False
 
     # JSON and Pickle
-    eq_(n, Namespace(n.to_json()))
-    eq_(n, pickle.loads(pickle.dumps(n)))
+    assert n == Namespace(n.to_json())
+    assert n == pickle.loads(pickle.dumps(n))

--- a/mwtypes/tests/test_revision.py
+++ b/mwtypes/tests/test_revision.py
@@ -1,7 +1,5 @@
 import pickle
 
-from nose.tools import eq_
-
 from ..page import Page
 from ..revision import Deleted, Revision
 from ..slots import Content, Slots
@@ -12,20 +10,20 @@ from ..user import User
 def test_revision():
     # No info
     r = Revision(10, Timestamp("20150101000000"))
-    eq_(r.id, 10)
-    eq_(r.timestamp, Timestamp("20150101000000"))
-    eq_(r.user, None)
-    eq_(r.page, None)
-    eq_(r.minor, None)
-    eq_(r.comment, None)
-    eq_(r.text, None)
-    eq_(r.bytes, None)
-    eq_(r.sha1, None)
-    eq_(r.parent_id, None)
-    eq_(r.model, None)
-    eq_(r.format, None)
-    eq_(r.deleted, None)
-    eq_(r.slots, None)
+    assert r.id == 10
+    assert r.timestamp == Timestamp("20150101000000")
+    assert r.user == None
+    assert r.page == None
+    assert r.minor == None
+    assert r.comment == None
+    assert r.text == None
+    assert r.bytes == None
+    assert r.sha1 == None
+    assert r.parent_id == None
+    assert r.model == None
+    assert r.format == None
+    assert r.deleted == None
+    assert r.slots == None
 
     # All info
     r = Revision(10, Timestamp("20150101000000"),
@@ -45,103 +43,103 @@ def test_revision():
                  parent_id=9,
                  deleted=Deleted(text=True, comment=False, user=False,
                                  restricted=False))
-    eq_(r.id, 10)
-    eq_(r.timestamp, Timestamp("20150101000000"))
-    eq_(r.user.id, 10)
-    eq_(r.user.text, "Foobar")
-    eq_(r.page.id, 12)
-    eq_(r.page.title, "Anarchism")
-    eq_(r.page.namespace, 2)
-    eq_(r.minor, False)
-    eq_(r.comment, "I have a lovely bunch of ...")
-    eq_(r.text, "I am the text")
-    eq_(r.slots['main'].text, "I am the text")
-    eq_(r.bytes, 257)
-    eq_(r.slots['main'].bytes, 257)
-    eq_(r.sha1, "fe5f4fe65fe765ef")
-    eq_(r.slots.sha1, "2345672bb")
-    eq_(r.model, "text")
-    eq_(r.slots['main'].model, "text")
-    eq_(r.format, "also_text")
-    eq_(r.slots['main'].format, "also_text")
-    eq_(r.parent_id, 9)
-    eq_(r.deleted.text, True)
-    eq_(r.deleted.comment, False)
-    eq_(r.deleted.user, False)
-    eq_(r.deleted.restricted, False)
+    assert r.id == 10
+    assert r.timestamp == Timestamp("20150101000000")
+    assert r.user.id == 10
+    assert r.user.text == "Foobar"
+    assert r.page.id == 12
+    assert r.page.title == "Anarchism"
+    assert r.page.namespace == 2
+    assert r.minor == False
+    assert r.comment == "I have a lovely bunch of ..."
+    assert r.text == "I am the text"
+    assert r.slots['main'].text == "I am the text"
+    assert r.bytes == 257
+    assert r.slots['main'].bytes == 257
+    assert r.sha1 == "fe5f4fe65fe765ef"
+    assert r.slots.sha1 == "2345672bb"
+    assert r.model == "text"
+    assert r.slots['main'].model == "text"
+    assert r.format == "also_text"
+    assert r.slots['main'].format == "also_text"
+    assert r.parent_id == 9
+    assert r.deleted.text == True
+    assert r.deleted.comment == False
+    assert r.deleted.user == False
+    assert r.deleted.restricted == False
 
     # JSON and Pickle
-    eq_(r, Revision(r.to_json()))
-    eq_(r, pickle.loads(pickle.dumps(r)))
+    assert r == Revision(r.to_json())
+    assert r == pickle.loads(pickle.dumps(r))
 
 
 def test_deleted():
     # No info
     d = Deleted()
-    eq_(d.text, None)
-    eq_(d.comment, None)
-    eq_(d.user, None)
-    eq_(d.restricted, None)
+    assert d.text == None
+    assert d.comment == None
+    assert d.user == None
+    assert d.restricted == None
 
     # Just one
     d = Deleted(text=True)
-    eq_(d.text, True)
-    eq_(d.comment, None)
-    eq_(d.user, None)
-    eq_(d.restricted, None)
+    assert d.text == True
+    assert d.comment == None
+    assert d.user == None
+    assert d.restricted == None
 
     # All
     d = Deleted(text=True, comment=False, user=True, restricted=False)
-    eq_(d.text, True)
-    eq_(d.comment, False)
-    eq_(d.user, True)
-    eq_(d.restricted, False)
+    assert d.text == True
+    assert d.comment == False
+    assert d.user == True
+    assert d.restricted == False
 
     d = Deleted.from_int(0)
-    eq_(d.text, False)
-    eq_(d.comment, False)
-    eq_(d.user, False)
-    eq_(d.restricted, False)
+    assert d.text == False
+    assert d.comment == False
+    assert d.user == False
+    assert d.restricted == False
 
     d = Deleted.from_int(3)
-    eq_(d.text, True)
-    eq_(d.comment, True)
-    eq_(d.user, False)
-    eq_(d.restricted, False)
+    assert d.text == True
+    assert d.comment == True
+    assert d.user == False
+    assert d.restricted == False
 
     d = Deleted.from_int(9)
-    eq_(d.text, True)
-    eq_(d.comment, False)
-    eq_(d.user, False)
-    eq_(d.restricted, True)
+    assert d.text == True
+    assert d.comment == False
+    assert d.user == False
+    assert d.restricted == True
 
     d = Deleted.from_int(15)
-    eq_(d.text, True)
-    eq_(d.comment, True)
-    eq_(d.user, True)
-    eq_(d.restricted, True)
+    assert d.text == True
+    assert d.comment == True
+    assert d.user == True
+    assert d.restricted == True
 
     # JSON and Pickle
-    eq_(d, Deleted(d.to_json()))
-    eq_(d, pickle.loads(pickle.dumps(d)))
+    assert d == Deleted(d.to_json())
+    assert d == pickle.loads(pickle.dumps(d))
 
 
 def test_user():
     # No info
     u = User()
-    eq_(u.id, None)
-    eq_(u.text, None)
+    assert u.id == None
+    assert u.text == None
 
     # Logged-in
     u = User(10, "Foobar")
-    eq_(u.id, 10)
-    eq_(u.text, "Foobar")
+    assert u.id == 10
+    assert u.text == "Foobar"
 
     # IP
     u = User(text="192.168.0.1")
-    eq_(u.id, None)
-    eq_(u.text, "192.168.0.1")
+    assert u.id == None
+    assert u.text == "192.168.0.1"
 
     # JSON and Pickle
-    eq_(u, User(u.to_json()))
-    eq_(u, pickle.loads(pickle.dumps(u)))
+    assert u == User(u.to_json())
+    assert u == pickle.loads(pickle.dumps(u))

--- a/mwtypes/tests/test_string_type.py
+++ b/mwtypes/tests/test_string_type.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_
-
 from ..string_type import StringType
 
 
@@ -13,6 +11,6 @@ class FooBar(StringType):
 def test_string_type():
 
     foobar = FooBar("foobar", 1, 2)
-    eq_(foobar, "foobar")
-    eq_(foobar.foo, 1)
-    eq_(foobar.bar, 2)
+    assert foobar == "foobar"
+    assert foobar.foo == 1
+    assert foobar.bar == 2

--- a/mwtypes/tests/test_timestamp.py
+++ b/mwtypes/tests/test_timestamp.py
@@ -1,7 +1,5 @@
 import pickle
 
-from nose.tools import eq_
-
 from ..timestamp import LONG_MW_TIME_STRING, Timestamp
 
 
@@ -9,13 +7,13 @@ def test_self():
     t1 = Timestamp(1234567890)
 
     # Unix timestamp
-    eq_(t1, Timestamp(int(t1)))
+    assert t1 == Timestamp(int(t1))
 
     # Short format
-    eq_(t1, Timestamp(t1.short_format()))
+    assert t1 == Timestamp(t1.short_format())
 
     # Long format
-    eq_(t1, Timestamp(t1.long_format()))
+    assert t1 == Timestamp(t1.long_format())
 
 
 def test_comparison():
@@ -40,48 +38,42 @@ def test_subtraction():
     t1 = Timestamp(1234567890)
     t2 = Timestamp(1234567891)
 
-    eq_(t2 - t1, 1)
-    eq_(t1 - t2, -1)
-    eq_(t2 - 1, t1)
+    assert t2 - t1 == 1
+    assert t1 - t2 == -1
+    assert t2 - 1 == t1
 
 
 def test_strptime():
-    eq_(
-        Timestamp("2009-02-13T23:31:30Z"),
-        Timestamp.strptime("2009-02-13T23:31:30Z", LONG_MW_TIME_STRING)
-    )
+    assert (
+        Timestamp("2009-02-13T23:31:30Z") ==
+        Timestamp.strptime("2009-02-13T23:31:30Z", LONG_MW_TIME_STRING))
 
-    eq_(
+    assert (
         Timestamp.strptime(
             "expires 03:20, 21 November 2013 (UTC)",
             "expires %H:%M, %d %B %Y (UTC)"
-        ),
-        Timestamp("2013-11-21T03:20:00Z")
-    )
+        ) ==
+        Timestamp("2013-11-21T03:20:00Z"))
 
 
 def test_strftime():
-    eq_(
-        Timestamp("2009-02-13T23:31:30Z").strftime(LONG_MW_TIME_STRING),
-        "2009-02-13T23:31:30Z"
-    )
+    assert (
+        Timestamp("2009-02-13T23:31:30Z").strftime(LONG_MW_TIME_STRING) ==
+        "2009-02-13T23:31:30Z")
 
-    eq_(
-        Timestamp("2009-02-13T23:31:30Z").strftime("expires %H:%M, %d %B %Y (UTC)"),
-        "expires 23:31, 13 February 2009 (UTC)"
-    )
+    assert (
+        Timestamp("2009-02-13T23:31:30Z").strftime("expires %H:%M, %d %B %Y (UTC)") ==
+        "expires 23:31, 13 February 2009 (UTC)")
 
 
 def test_json():
     timestamp = Timestamp(1234567890)
-    eq_(
-        timestamp,
-        Timestamp.from_json(timestamp.to_json())
-    )
+    assert (
+        timestamp ==
+        Timestamp.from_json(timestamp.to_json()))
 
 def test_pickling():
     timestamp = Timestamp(1234567890)
-    eq_(
-        timestamp,
-        pickle.loads(pickle.dumps(timestamp))
-    )
+    assert (
+        timestamp ==
+        pickle.loads(pickle.dumps(timestamp)))

--- a/mwtypes/tests/test_upload.py
+++ b/mwtypes/tests/test_upload.py
@@ -1,7 +1,5 @@
 import pickle
 
-from nose.tools import eq_
-
 from ..timestamp import Timestamp
 from ..upload import Upload
 from ..user import User
@@ -10,12 +8,12 @@ from ..user import User
 def test_upload():
     # No info
     u = Upload(Timestamp("20150101000000"))
-    eq_(u.timestamp, Timestamp("20150101000000"))
-    eq_(u.user, None)
-    eq_(u.comment, None)
-    eq_(u.filename, None)
-    eq_(u.source, None)
-    eq_(u.size, None)
+    assert u.timestamp == Timestamp("20150101000000")
+    assert u.user == None
+    assert u.comment == None
+    assert u.filename == None
+    assert u.source == None
+    assert u.size == None
 
     # All info
     u = Upload(Timestamp("20150101000000"),
@@ -24,14 +22,14 @@ def test_upload():
                filename="Foo_bar.jpg",
                source="https://foo",
                size=345678)
-    eq_(u.timestamp, Timestamp("20150101000000"))
-    eq_(u.comment, "I have a lovely bunch of ...")
-    eq_(u.user.id, 10)
-    eq_(u.user.text, "Foobar")
-    eq_(u.filename, "Foo_bar.jpg")
-    eq_(u.source, "https://foo")
-    eq_(u.size, 345678)
+    assert u.timestamp == Timestamp("20150101000000")
+    assert u.comment == "I have a lovely bunch of ..."
+    assert u.user.id == 10
+    assert u.user.text == "Foobar"
+    assert u.filename == "Foo_bar.jpg"
+    assert u.source == "https://foo"
+    assert u.size == 345678
 
     # JSON and Pickle
-    eq_(u, Upload(u.to_json()))
-    eq_(u, pickle.loads(pickle.dumps(u)))
+    assert u == Upload(u.to_json())
+    assert u == pickle.loads(pickle.dumps(u))

--- a/mwtypes/tests/test_user.py
+++ b/mwtypes/tests/test_user.py
@@ -1,26 +1,24 @@
 import pickle
 
-from nose.tools import eq_
-
 from ..user import User
 
 
 def test_user():
     # No info
     u = User()
-    eq_(u.id, None)
-    eq_(u.text, None)
+    assert u.id == None
+    assert u.text == None
 
     # Logged-in
     u = User(10, "Foobar")
-    eq_(u.id, 10)
-    eq_(u.text, "Foobar")
+    assert u.id == 10
+    assert u.text == "Foobar"
 
     # IP
     u = User(text="192.168.0.1")
-    eq_(u.id, None)
-    eq_(u.text, "192.168.0.1")
+    assert u.id == None
+    assert u.text == "192.168.0.1"
 
     # JSON and Pickle
-    eq_(u, User(u.to_json()))
-    eq_(u, pickle.loads(pickle.dumps(u)))
+    assert u == User(u.to_json())
+    assert u == pickle.loads(pickle.dumps(u))


### PR DESCRIPTION
This migrates the test suite of mwtypes to pytest and the stdlib's unittest, from nose. nose is now deprecated, and projects should now use pytest and/or unittest. As part of an effort in the nixpkgs project(https://github.com/NixOS/nixpkgs/issues/326513), we are removing all usages of nose in our package set, and submitting patches to upstream projects to help them migrate more easily.

Thank you, and have a wonderful day! I would be glad to answer any questions you have about this PR.